### PR TITLE
Fix truncated method name

### DIFF
--- a/jvmtop.sh
+++ b/jvmtop.sh
@@ -17,7 +17,7 @@ if [ ! -f "$TOOLSJAR" ] ; then
         echo "$JAVA_HOME seems to be no JDK!" >&2
         exit 1
 fi
-
-"$JAVA_HOME"/bin/java $JAVA_OPTS -cp "$DIR/jvmtop.jar:$TOOLSJAR" \
+echo "DIR is : $DIR"
+"$JAVA_HOME"/bin/java $JAVA_OPTS -cp "$DIR/target/jvmtop-0.9.0-SNAPSHOT.jar:$TOOLSJAR" \
 com.jvmtop.JvmTop "$@"
 exit $?

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,21 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>  
+            </plugin>
+            <plugin>
+                <!-- Build an executable JAR -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.jvmtop.JvmTop</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.jvmtop.JvmTop</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
                 <executions>
                     <execution>
@@ -91,20 +96,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <!-- Build an executable JAR -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>com.jvmtop.JvmTop</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/jvmtop/view/VMProfileView.java
+++ b/src/main/java/com/jvmtop/view/VMProfileView.java
@@ -118,7 +118,8 @@ public class VMProfileView extends AbstractConsoleView
     String line = fqn + "." + method;
     if (line.length() > size)
     {
-      line = "..." + line.substring(3, size);
+      int start = line.length() - size + 3;
+      line = "..." + line.substring(start);
     }
     return line;
   }


### PR DESCRIPTION
This PR fixes #1 
After the fix, the suffix of the full method name will be displayed in the `profile` mode instead of the prefix, making it more informative.

### Building and running the `jvmtop` project
At project root, use:
`mvn clean package` 
to build the binary `jvmtop-0.9.0-SNAPSHOT.jar` in `/target`.

To find out all Java processes running:
`sh jvmtop.sh`
This gives a list of currently running Java processes with the `pid`s.
To monitor method-level profiling, use:
`sh jvmtop.sh --profile <pid>`
where `<pid>` is the process id of the java process to be monitored.